### PR TITLE
Make Pongo2 render work with go-bindata.

### DIFF
--- a/pongo2.go
+++ b/pongo2.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"path"
 	"strings"
 	"sync"
 	"time"
@@ -45,11 +44,11 @@ func compile(opt Options) map[string]*pongo2.Template {
 		opt.TemplateFileSystem = macaron.NewTemplateFileSystem(macaron.RenderOptions{
 			Directory:  opt.Directory,
 			Extensions: opt.Extensions,
-		}, true)
+		}, false)
 	}
 
 	for _, f := range opt.TemplateFileSystem.ListFiles() {
-		t, err := pongo2.FromFile(path.Join(opt.Directory, f.Name()) + f.Ext())
+		t, err := pongo2.FromString(string(f.Data()))
 		if err != nil {
 			// Bomb out if parse fails. We don't want any silent server starts.
 			log.Fatalf("\"%s\": %v", f.Name(), err)


### PR DESCRIPTION
Pongo2 renderer does not work with go-bindata, since it tries to read the template FromFile. This change reads the template from f.Data. This now works with both Files and Bindata.